### PR TITLE
Add Fastify RBAC example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# RBAC
+# RBAC Fastify API
+
+Esta API demonstra um controle de acesso baseado em papeis (RBAC) usando Fastify e PostgreSQL.
+
+## Requisitos
+
+- Node.js 20+
+- PostgreSQL
+
+## Instalação
+
+1. Copie o arquivo `db.sql` para o seu banco de dados e execute para criar as tabelas.
+2. Defina a variável de ambiente `DATABASE_URL` com a conexão do Postgres.
+3. Instale as dependências:
+
+```bash
+npm install
+```
+
+4. Inicie o servidor:
+
+```bash
+npm start
+```
+
+A API ficará disponível em `http://localhost:3000`.
+
+## Uso
+
+Envie o cabeçalho `user-id` com o id do usuário autenticado para que as permissões sejam avaliadas. A rota `/admin` exige que o usuário tenha o papel `admin` e a rota `/profile` exige o papel `user`.

--- a/db.sql
+++ b/db.sql
@@ -1,0 +1,17 @@
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  password TEXT NOT NULL
+);
+
+CREATE TABLE roles (
+  id SERIAL PRIMARY KEY,
+  name TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE user_roles (
+  user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+  role_name TEXT REFERENCES roles(name) ON DELETE CASCADE
+);
+
+INSERT INTO roles(name) VALUES ('admin'), ('user');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "rbac-api",
+  "version": "1.0.0",
+  "description": "Fastify API with PostgreSQL RBAC",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node --watch server.js"
+  },
+  "dependencies": {
+    "fastify": "^4.26.0",
+    "fastify-plugin": "^4.5.2",
+    "pg": "^8.11.3"
+  }
+}

--- a/plugins/db.js
+++ b/plugins/db.js
@@ -1,0 +1,14 @@
+import fp from 'fastify-plugin';
+import pkg from 'pg';
+
+const { Pool } = pkg;
+
+async function dbPlugin(fastify) {
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  fastify.decorate('pg', pool);
+  fastify.addHook('onClose', async () => {
+    await pool.end();
+  });
+}
+
+export default fp(dbPlugin);

--- a/plugins/rbac.js
+++ b/plugins/rbac.js
@@ -1,0 +1,39 @@
+import fp from 'fastify-plugin';
+
+async function rbacPlugin(fastify) {
+  fastify.decorateRequest('user', null);
+  fastify.decorate('rbac', {
+    async verifyUser(request) {
+      const userId = request.headers['user-id'];
+      if (!userId) return null;
+      const { rows } = await fastify.pg.query(
+        'SELECT id, email FROM users WHERE id=$1',
+        [userId]
+      );
+      request.user = rows[0];
+      if (!request.user) return null;
+      const rolesRes = await fastify.pg.query(
+        'SELECT role_name FROM user_roles WHERE user_id=$1',
+        [userId]
+      );
+      request.user.roles = rolesRes.rows.map(r => r.role_name);
+      return request.user;
+    },
+    requireRole(role) {
+      return async function (request, reply) {
+        if (!request.user) {
+          await fastify.rbac.verifyUser(request);
+        }
+        if (!request.user || !request.user.roles.includes(role)) {
+          reply.code(403).send({ error: 'forbidden' });
+        }
+      };
+    }
+  });
+
+  fastify.addHook('preHandler', async (request) => {
+    await fastify.rbac.verifyUser(request);
+  });
+}
+
+export default fp(rbacPlugin);

--- a/server.js
+++ b/server.js
@@ -1,0 +1,33 @@
+import Fastify from 'fastify';
+import pgPlugin from './plugins/db.js';
+import rbacPlugin from './plugins/rbac.js';
+
+const fastify = Fastify({ logger: true });
+
+await fastify.register(pgPlugin);
+await fastify.register(rbacPlugin);
+
+fastify.get('/', async () => ({ status: 'ok' }));
+
+fastify.get('/admin', {
+  preHandler: fastify.rbac.requireRole('admin'),
+}, async () => {
+  return { message: 'hello admin' };
+});
+
+fastify.get('/profile', {
+  preHandler: fastify.rbac.requireRole('user'),
+}, async (request) => {
+  const user = await fastify.pg.query(
+    'SELECT id, email FROM users WHERE id=$1',
+    [request.user.id]
+  );
+  return { profile: user.rows[0] };
+});
+
+try {
+  await fastify.listen({ port: process.env.PORT || 3000, host: '0.0.0.0' });
+} catch (err) {
+  fastify.log.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- create Fastify server with RBAC check backed by PostgreSQL
- add plugins for PostgreSQL connection and RBAC role checking
- include a sample SQL schema
- provide npm project files and instructions

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506acdd808832c87f2e1dda685da6e